### PR TITLE
Change the import order of jar files in -cp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ new WireMockServer(wireMockConfig().extensions(new VelocityResponseTransformer()
 
 - From the command line **NOTE : Change the versions of the jars to match the one's you have downloaded.**
 ````
-java -cp "wiremock-velocity-transformer-standalone-1.4.jar:wiremock-standalone-2.1.12.jar" com.github.tomakehurst.wiremock.standalone.WireMockServerRunner --verbose --extensions com.github.adamyork.wiremock.transformer.VelocityResponseTransformer
+java -cp "wiremock-standalone-2.1.12.jar:wiremock-velocity-transformer-standalone-1.4.jar" com.github.tomakehurst.wiremock.standalone.WireMockServerRunner --verbose --extensions com.github.adamyork.wiremock.transformer.VelocityResponseTransformer
 ````


### PR DESCRIPTION
Changed the order in the import of jars because in the old way, wiremock is not accepting some parameters such as --global-response-templating to use handlebars besides the velocity extension. Specifying first the wiremock-standalone jar does the trick because it takes the last version of WireMockServerRunner and not the probably old one contained in the wiremock-velocity-transformer-standalone-1.4.jar version.

In this way I could execute this command with no problems at all: java -cp "wiremock-standalone-2.5.0.jar:wiremock-velocity-transformer-standalone-1.4.jar" com.github.tomakehurst.wiremock.standalone.WireMockServerRunner --global-response-templating --extensions com.github.adamyork.wiremock.transformer.VelocityResponseTransformer --verbose